### PR TITLE
Allow more convention customisation

### DIFF
--- a/sample/Futurum.WebApiEndpoint.Micro.Sample.Addition/AdditionWebApiEndpoint.cs
+++ b/sample/Futurum.WebApiEndpoint.Micro.Sample.Addition/AdditionWebApiEndpoint.cs
@@ -5,10 +5,6 @@ namespace Futurum.WebApiEndpoint.Micro.Sample.Addition;
 [WebApiEndpoint(prefixRoute: "addition")]
 public class AdditionWebApiEndpoint : IWebApiEndpoint
 {
-    public void Configure(RouteGroupBuilder groupBuilder, WebApiEndpointVersion webApiEndpointVersion)
-    {
-    }
-
     public void Register(IEndpointRouteBuilder builder)
     {
         builder.MapGet("/", GetHandler);

--- a/sample/Futurum.WebApiEndpoint.Micro.Sample/Blog/BlogWebApiEndpoint.cs
+++ b/sample/Futurum.WebApiEndpoint.Micro.Sample/Blog/BlogWebApiEndpoint.cs
@@ -3,10 +3,6 @@ namespace Futurum.WebApiEndpoint.Micro.Sample.Blog;
 [WebApiEndpoint("blog")]
 public class BlogWebApiEndpoint : IWebApiEndpoint
 {
-    public void Configure(RouteGroupBuilder groupBuilder, WebApiEndpointVersion webApiEndpointVersion)
-    {
-    }
-
     public void Register(IEndpointRouteBuilder builder)
     {
         builder.MapGet("/", GetHandler);

--- a/sample/Futurum.WebApiEndpoint.Micro.Sample/Features/AsyncEnumerableWebApiEndpoint.cs
+++ b/sample/Futurum.WebApiEndpoint.Micro.Sample/Features/AsyncEnumerableWebApiEndpoint.cs
@@ -3,10 +3,6 @@ namespace Futurum.WebApiEndpoint.Micro.Sample.Features;
 [WebApiEndpoint("async-enumerable", "feature")]
 public class AsyncEnumerableWebApiEndpoint : IWebApiEndpoint
 {
-    public void Configure(RouteGroupBuilder groupBuilder, WebApiEndpointVersion webApiEndpointVersion)
-    {
-    }
-
     public void Register(IEndpointRouteBuilder builder)
     {
         builder.MapGet("/", GetHandler);

--- a/sample/Futurum.WebApiEndpoint.Micro.Sample/Features/BytesWebApiEndpoint.cs
+++ b/sample/Futurum.WebApiEndpoint.Micro.Sample/Features/BytesWebApiEndpoint.cs
@@ -5,10 +5,6 @@ namespace Futurum.WebApiEndpoint.Micro.Sample.Features;
 [WebApiEndpoint("bytes", "feature")]
 public class BytesWebApiEndpoint : IWebApiEndpoint
 {
-    public void Configure(RouteGroupBuilder groupBuilder, WebApiEndpointVersion webApiEndpointVersion)
-    {
-    }
-
     public void Register(IEndpointRouteBuilder builder)
     {
         builder.MapGet("download", DownloadHandler);

--- a/sample/Futurum.WebApiEndpoint.Micro.Sample/Features/DataCollectionWebApiEndpoint.cs
+++ b/sample/Futurum.WebApiEndpoint.Micro.Sample/Features/DataCollectionWebApiEndpoint.cs
@@ -3,10 +3,6 @@ namespace Futurum.WebApiEndpoint.Micro.Sample.Features;
 [WebApiEndpoint("data-collection", "feature")]
 public class DataCollectionWebApiEndpoint : IWebApiEndpoint
 {
-    public void Configure(RouteGroupBuilder groupBuilder, WebApiEndpointVersion webApiEndpointVersion)
-    {
-    }
-
     public void Register(IEndpointRouteBuilder builder)
     {
         builder.MapGet("/", GetHandler);

--- a/sample/Futurum.WebApiEndpoint.Micro.Sample/Features/ErrorWebApiEndpoint.cs
+++ b/sample/Futurum.WebApiEndpoint.Micro.Sample/Features/ErrorWebApiEndpoint.cs
@@ -3,10 +3,6 @@ namespace Futurum.WebApiEndpoint.Micro.Sample.Features;
 [WebApiEndpoint(prefixRoute: "error", group: "feature")]
 public class ErrorWebApiEndpoint : IWebApiEndpoint
 {
-    public void Configure(RouteGroupBuilder groupBuilder, WebApiEndpointVersion webApiEndpointVersion)
-    {
-    }
-
     public void Register(IEndpointRouteBuilder builder)
     {
         builder.MapGet("exception", ExceptionHandler);

--- a/sample/Futurum.WebApiEndpoint.Micro.Sample/Features/FileWebApiEndpoint.cs
+++ b/sample/Futurum.WebApiEndpoint.Micro.Sample/Features/FileWebApiEndpoint.cs
@@ -6,10 +6,6 @@ namespace Futurum.WebApiEndpoint.Micro.Sample.Features;
 [WebApiEndpoint(prefixRoute: "file", group: "feature")]
 public class FileWebApiEndpoint : IWebApiEndpoint
 {
-    public void Configure(RouteGroupBuilder groupBuilder, WebApiEndpointVersion webApiEndpointVersion)
-    {
-    }
-
     public void Register(IEndpointRouteBuilder builder)
     {
         builder.MapPost("upload", UploadHandler)

--- a/sample/Futurum.WebApiEndpoint.Micro.Sample/Features/ValidationWebApiEndpoint.cs
+++ b/sample/Futurum.WebApiEndpoint.Micro.Sample/Features/ValidationWebApiEndpoint.cs
@@ -7,10 +7,6 @@ namespace Futurum.WebApiEndpoint.Micro.Sample.Features;
 [WebApiEndpoint("validation")]
 public class ValidationWebApiEndpoint : IWebApiEndpoint
 {
-    public void Configure(RouteGroupBuilder groupBuilder, WebApiEndpointVersion webApiEndpointVersion)
-    {
-    }
-
     public void Register(IEndpointRouteBuilder builder)
     {
         builder.MapPost("/fluent-validation", FluentValidationHandler);

--- a/sample/Futurum.WebApiEndpoint.Micro.Sample/OpenApi/OpenApiVersionV0WebApiEndpoint.cs
+++ b/sample/Futurum.WebApiEndpoint.Micro.Sample/OpenApi/OpenApiVersionV0WebApiEndpoint.cs
@@ -6,10 +6,6 @@ namespace Futurum.WebApiEndpoint.Micro.Sample.OpenApi;
 [WebApiEndpointVersions.V0_1]
 public class OpenApiVersionV0WebApiEndpoint : IWebApiEndpoint
 {
-    public void Configure(RouteGroupBuilder groupBuilder, WebApiEndpointVersion webApiEndpointVersion)
-    {
-    }
-
     public void Register(IEndpointRouteBuilder builder)
     {
         builder.MapGet("/", GetHandler);

--- a/sample/Futurum.WebApiEndpoint.Micro.Sample/OpenApi/OpenApiVersionV1WebApiEndpoint.cs
+++ b/sample/Futurum.WebApiEndpoint.Micro.Sample/OpenApi/OpenApiVersionV1WebApiEndpoint.cs
@@ -7,10 +7,6 @@ namespace Futurum.WebApiEndpoint.Micro.Sample.OpenApi;
 [WebApiEndpointVersions.V3_0]
 public class OpenApiVersionV1WebApiEndpoint : IWebApiEndpoint
 {
-    public void Configure(RouteGroupBuilder groupBuilder, WebApiEndpointVersion webApiEndpointVersion)
-    {
-    }
-
     public void Register(IEndpointRouteBuilder builder)
     {
         builder.MapGet("/", GetHandler);

--- a/sample/Futurum.WebApiEndpoint.Micro.Sample/OpenApi/OpenApiVersionV2WebApiEndpoint.cs
+++ b/sample/Futurum.WebApiEndpoint.Micro.Sample/OpenApi/OpenApiVersionV2WebApiEndpoint.cs
@@ -6,10 +6,6 @@ namespace Futurum.WebApiEndpoint.Micro.Sample.OpenApi;
 [WebApiEndpointVersions.V2_0]
 public class OpenApiVersionV2WebApiEndpoint : IWebApiEndpoint
 {
-    public void Configure(RouteGroupBuilder groupBuilder, WebApiEndpointVersion webApiEndpointVersion)
-    {
-    }
-
     public void Register(IEndpointRouteBuilder builder)
     {
         builder.MapGet("/", GetHandler);

--- a/sample/Futurum.WebApiEndpoint.Micro.Sample/Security/SecurityLoginWebApiEndpoint.cs
+++ b/sample/Futurum.WebApiEndpoint.Micro.Sample/Security/SecurityLoginWebApiEndpoint.cs
@@ -9,10 +9,6 @@ namespace Futurum.WebApiEndpoint.Micro.Sample.Security;
 [WebApiEndpoint("security")]
 public class SecurityLoginWebApiEndpoint : IWebApiEndpoint
 {
-    public void Configure(RouteGroupBuilder groupBuilder, WebApiEndpointVersion webApiEndpointVersion)
-    {
-    }
-
     public void Register(IEndpointRouteBuilder builder)
     {
         builder.MapGet("login", LoginHandler);

--- a/sample/Futurum.WebApiEndpoint.Micro.Sample/Todo/TodoApiWebApiEndpoint.cs
+++ b/sample/Futurum.WebApiEndpoint.Micro.Sample/Todo/TodoApiWebApiEndpoint.cs
@@ -5,10 +5,6 @@ namespace Futurum.WebApiEndpoint.Micro.Sample.Todo;
 [WebApiEndpoint("api/todos", "todos")]
 public class TodoApiWebApiEndpoint : IWebApiEndpoint
 {
-    public void Configure(RouteGroupBuilder groupBuilder, WebApiEndpointVersion webApiEndpointVersion)
-    {
-    }
-
     public void Register(IEndpointRouteBuilder builder)
     {
         builder.MapGet("/", GetAllHandler)

--- a/sample/Futurum.WebApiEndpoint.Micro.Sample/WeatherForecast/WeatherWebApiEndpoint.cs
+++ b/sample/Futurum.WebApiEndpoint.Micro.Sample/WeatherForecast/WeatherWebApiEndpoint.cs
@@ -8,10 +8,6 @@ public class WeatherWebApiEndpoint : IWebApiEndpoint
         "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
     };
 
-    public void Configure(RouteGroupBuilder groupBuilder, WebApiEndpointVersion webApiEndpointVersion)
-    {
-    }
-
     public void Register(IEndpointRouteBuilder builder)
     {
         builder.MapGet("/", GetHandler);

--- a/src/Futurum.WebApiEndpoint.Micro/IWebApiEndpoint.cs
+++ b/src/Futurum.WebApiEndpoint.Micro/IWebApiEndpoint.cs
@@ -22,7 +22,9 @@ public interface IWebApiEndpoint
     /// <summary>
     /// Configure the <see cref="RouteGroupBuilder"/>, can be individually configured for each <see cref="WebApiEndpointVersion"/>
     /// </summary>
-    void Configure(RouteGroupBuilder groupBuilder, WebApiEndpointVersion webApiEndpointVersion);
+    void Configure(RouteGroupBuilder groupBuilder, WebApiEndpointVersion webApiEndpointVersion)
+    {
+    }
 
     /// <summary>
     /// Register RouteEndpoint(s) to the IEndpointRouteBuilder

--- a/src/Futurum.WebApiEndpoint.Micro/IWebApiEndpointMetadataStrategy.cs
+++ b/src/Futurum.WebApiEndpoint.Micro/IWebApiEndpointMetadataStrategy.cs
@@ -1,0 +1,7 @@
+namespace Futurum.WebApiEndpoint.Micro;
+
+public interface IWebApiEndpointMetadataStrategy
+{
+    IEnumerable<WebApiEndpointMetadata> Get<TWebApiEndpoint>(WebApiEndpointConfiguration configuration, TWebApiEndpoint webApiEndpoint)
+        where TWebApiEndpoint : IWebApiEndpoint;
+}

--- a/src/Futurum.WebApiEndpoint.Micro/WebApiEndpointAttribute.cs
+++ b/src/Futurum.WebApiEndpoint.Micro/WebApiEndpointAttribute.cs
@@ -6,17 +6,21 @@ namespace Futurum.WebApiEndpoint.Micro;
 [AttributeUsage(AttributeTargets.Class)]
 public sealed class WebApiEndpointAttribute : Attribute
 {
+    public WebApiEndpointAttribute()
+    {
+    }
+
     public WebApiEndpointAttribute(string? prefixRoute = null)
     {
         PrefixRoute = prefixRoute;
     }
-    
+
     public WebApiEndpointAttribute(string? prefixRoute = null, string? group = null)
     {
         PrefixRoute = prefixRoute;
         Group = group;
     }
-    
+
     public string? PrefixRoute { get; }
     public string? Group { get; }
 }

--- a/src/Futurum.WebApiEndpoint.Micro/WebApiEndpointMetadata.cs
+++ b/src/Futurum.WebApiEndpoint.Micro/WebApiEndpointMetadata.cs
@@ -1,0 +1,3 @@
+namespace Futurum.WebApiEndpoint.Micro;
+
+public record WebApiEndpointMetadata(string PrefixRoute, string Tag, WebApiEndpointVersion WebApiEndpointVersion);

--- a/src/Futurum.WebApiEndpoint.Micro/WebApiEndpointMetadataAttributeStrategy.cs
+++ b/src/Futurum.WebApiEndpoint.Micro/WebApiEndpointMetadataAttributeStrategy.cs
@@ -1,0 +1,67 @@
+using System.Reflection;
+
+namespace Futurum.WebApiEndpoint.Micro;
+
+public class WebApiEndpointMetadataAttributeStrategy : IWebApiEndpointMetadataStrategy
+{
+    public IEnumerable<WebApiEndpointMetadata> Get<TWebApiEndpoint>(WebApiEndpointConfiguration configuration, TWebApiEndpoint webApiEndpoint)
+        where TWebApiEndpoint : IWebApiEndpoint
+    {
+        var webApiEndpointType = webApiEndpoint.GetType();
+        
+        var webApiEndpointAttribute = webApiEndpointType.GetCustomAttribute<WebApiEndpointAttribute>();
+
+        var webApiVersionAttributes = webApiEndpoint.GetType().GetCustomAttributes<WebApiEndpointVersionAttribute>();
+
+        if (!webApiVersionAttributes.Any())
+        {
+            var tag = GetTag(webApiEndpointAttribute);
+
+            var webApiEndpointVersion = GetVersion(configuration.DefaultWebApiEndpointVersion, null);
+
+            var prefixRoute = GetPrefixRoute(configuration, webApiEndpointAttribute);
+
+            yield return new WebApiEndpointMetadata(prefixRoute, tag, webApiEndpointVersion);
+        }
+        else
+        {
+            foreach (var webApiVersionAttribute in webApiVersionAttributes)
+            {
+                var tag = GetTag(webApiEndpointAttribute);
+
+                var webApiEndpointVersion = GetVersion(configuration.DefaultWebApiEndpointVersion, webApiVersionAttribute);
+
+                var prefixRoute = GetPrefixRoute(configuration, webApiEndpointAttribute);
+
+                yield return new WebApiEndpointMetadata(prefixRoute, tag, webApiEndpointVersion);
+            }
+        }
+    }
+
+    private static string GetPrefixRoute(WebApiEndpointConfiguration configuration, WebApiEndpointAttribute? webApiEndpointAttribute)
+    {
+        var prefixRoute = webApiEndpointAttribute?.PrefixRoute ?? string.Empty;
+
+        return $"{configuration.VersionPrefix}{{version:apiVersion}}/{prefixRoute}";
+    }
+
+    private static string GetTag(WebApiEndpointAttribute? webApiEndpointAttribute)
+    {
+        if (webApiEndpointAttribute?.Group != null)
+        {
+            return webApiEndpointAttribute.Group;
+        }
+
+        if (webApiEndpointAttribute?.PrefixRoute != null)
+        {
+            return webApiEndpointAttribute.PrefixRoute;
+        }
+
+        return string.Empty;
+    }
+
+    private static WebApiEndpointVersion GetVersion(WebApiEndpointVersion webApiEndpointVersion, WebApiEndpointVersionAttribute? webApiVersionAttribute) =>
+        webApiVersionAttribute != null
+            ? new WebApiEndpointVersion(webApiVersionAttribute.MajorVersion, webApiVersionAttribute.MinorVersion)
+            : webApiEndpointVersion;
+}

--- a/src/Futurum.WebApiEndpoint.Micro/WebApplicationStartupExtensions.AddWebApiEndpointMetadataStrategy.cs
+++ b/src/Futurum.WebApiEndpoint.Micro/WebApplicationStartupExtensions.AddWebApiEndpointMetadataStrategy.cs
@@ -1,0 +1,15 @@
+namespace Futurum.WebApiEndpoint.Micro;
+
+public static partial class WebApplicationStartupExtensions
+{
+    /// <summary>
+    /// Add a custom version of <see cref="IWebApiEndpointMetadataStrategy"/>
+    /// </summary>
+    public static IServiceCollection AddWebApiEndpointMetadataStrategy<TMetadataStrategy>(this IServiceCollection serviceCollection)
+        where TMetadataStrategy : class, IWebApiEndpointMetadataStrategy
+    {
+        serviceCollection.AddSingleton<IWebApiEndpointMetadataStrategy, TMetadataStrategy>();
+
+        return serviceCollection;
+    }
+}

--- a/src/Futurum.WebApiEndpoint.Micro/WebApplicationStartupExtensions.AddWebApiEndpointOpenApiVersionConfigurationService.cs
+++ b/src/Futurum.WebApiEndpoint.Micro/WebApplicationStartupExtensions.AddWebApiEndpointOpenApiVersionConfigurationService.cs
@@ -1,0 +1,15 @@
+namespace Futurum.WebApiEndpoint.Micro;
+
+public static partial class WebApplicationStartupExtensions
+{
+    /// <summary>
+    /// Add a custom version of <see cref="IWebApiOpenApiVersionConfigurationService"/>
+    /// </summary>
+    public static IServiceCollection AddWebApiEndpointOpenApiVersionConfigurationService<TOpenApiVersionConfigurationService>(this IServiceCollection serviceCollection)
+        where TOpenApiVersionConfigurationService : class, IWebApiOpenApiVersionConfigurationService
+    {
+        serviceCollection.AddSingleton<IWebApiOpenApiVersionConfigurationService, TOpenApiVersionConfigurationService>();
+
+        return serviceCollection;
+    }
+}

--- a/src/Futurum.WebApiEndpoint.Micro/WebApplicationStartupExtensions.AddWebApiEndpointOpenApiVersionUIConfigurationService.cs
+++ b/src/Futurum.WebApiEndpoint.Micro/WebApplicationStartupExtensions.AddWebApiEndpointOpenApiVersionUIConfigurationService.cs
@@ -1,0 +1,15 @@
+namespace Futurum.WebApiEndpoint.Micro;
+
+public static partial class WebApplicationStartupExtensions
+{
+    /// <summary>
+    /// Add a custom version of <see cref="IWebApiOpenApiVersionUIConfigurationService"/>
+    /// </summary>
+    public static IServiceCollection AddWebApiEndpointOpenApiVersionUIConfigurationService<TOpenApiVersionUIConfigurationService>(this IServiceCollection serviceCollection)
+        where TOpenApiVersionUIConfigurationService : class, IWebApiOpenApiVersionUIConfigurationService
+    {
+        serviceCollection.AddSingleton<IWebApiOpenApiVersionUIConfigurationService, TOpenApiVersionUIConfigurationService>();
+
+        return serviceCollection;
+    }
+}

--- a/src/Futurum.WebApiEndpoint.Micro/WebApplicationStartupExtensions.AddWebApiEndpoints.cs
+++ b/src/Futurum.WebApiEndpoint.Micro/WebApplicationStartupExtensions.AddWebApiEndpoints.cs
@@ -20,17 +20,17 @@ public static partial class WebApplicationStartupExtensions
     /// Adds services for WebApiEndpoints
     /// <para>Allowing you to provide your own <see cref="IWebApiVersionConfigurationService"/></para>
     /// </summary>
-    public static IServiceCollection AddWebApiEndpoints<TWebApiVersionConfigurationService>(this IServiceCollection serviceCollection, WebApiEndpointConfiguration configuration)
-        where TWebApiVersionConfigurationService : class, IWebApiVersionConfigurationService, new()
+    public static IServiceCollection AddWebApiEndpoints<TVersionConfigurationService>(this IServiceCollection serviceCollection, WebApiEndpointConfiguration configuration)
+        where TVersionConfigurationService : class, IWebApiVersionConfigurationService, new()
     {
         serviceCollection.AddEndpointsApiExplorer();
         serviceCollection.AddSwaggerGen();
-        
+
         serviceCollection.AddSingleton(configuration);
 
         serviceCollection.RegisterModule<FuturumWebApiEndpointMicroModule>();
 
-        var webApiVersionConfigurationService = new TWebApiVersionConfigurationService();
+        var webApiVersionConfigurationService = new TVersionConfigurationService();
 
         serviceCollection.AddApiVersioning(webApiVersionConfigurationService, configuration, configuration.DefaultWebApiEndpointVersion);
 
@@ -42,8 +42,10 @@ public static partial class WebApplicationStartupExtensions
     {
         serviceCollection.AddSingleton<IConfigureOptions<SwaggerGenOptions>, WebApiOpenApiSwaggerOptions>();
 
-        serviceCollection.AddSingleton<IWebApiOpenApiVersionConfigurationService, WebApiOpenApiVersionConfigurationService>();
-        serviceCollection.AddSingleton<IWebApiOpenApiVersionUIConfigurationService, WebApiOpenApiVersionUIConfigurationService>();
+        serviceCollection.AddWebApiEndpointOpenApiVersionConfigurationService<WebApiOpenApiVersionConfigurationService>();
+        serviceCollection.AddWebApiEndpointOpenApiVersionUIConfigurationService<WebApiOpenApiVersionUIConfigurationService>();
+
+        serviceCollection.AddWebApiEndpointMetadataStrategy<WebApiEndpointMetadataAttributeStrategy>();
 
         serviceCollection.AddApiVersioning(options => webApiVersionConfigurationService.ConfigureApiVersioning(options, defaultWebApiVersion))
                          .AddApiExplorer(options => webApiVersionConfigurationService.ConfigureApiExplorer(options, configuration))

--- a/test/Futurum.WebApiEndpoint.Micro.Tests/WebApiEndpointMetadataAttributeStrategyTests.cs
+++ b/test/Futurum.WebApiEndpoint.Micro.Tests/WebApiEndpointMetadataAttributeStrategyTests.cs
@@ -1,0 +1,333 @@
+using FluentAssertions;
+
+using Microsoft.AspNetCore.Routing;
+
+namespace Futurum.WebApiEndpoint.Micro.Tests;
+
+public class WebApiEndpointMetadataAttributeStrategyTests
+{
+    public class one_version
+    {
+        private const string ROUTE = "route";
+        private const string TAG = "tag";
+
+        public static readonly WebApiEndpointVersion V_DEFAULT = new(1, 0);
+        public static readonly WebApiEndpointVersion V0_1 = new(0, 1);
+
+        [Fact]
+        public void all_populated()
+        {
+            var configuration = new WebApiEndpointConfiguration(V_DEFAULT);
+
+            var webApiEndpoint = new AllPopulatedWebApiEndpoint();
+
+            var metadataAttributeStrategy = new WebApiEndpointMetadataAttributeStrategy();
+
+            var metadatas = metadataAttributeStrategy.Get(configuration, webApiEndpoint);
+
+            metadatas.Count().Should().Be(1);
+
+            var metadata = metadatas.Single();
+
+            metadata.PrefixRoute.Should().Be($"v{{version:apiVersion}}/{ROUTE}");
+            metadata.Tag.Should().Be(TAG);
+            metadata.WebApiEndpointVersion.Should().Be(V0_1);
+        }
+
+        [Fact]
+        public void version_missing()
+        {
+            var configuration = new WebApiEndpointConfiguration(V_DEFAULT);
+
+            var webApiEndpoint = new VersionMissingWebApiEndpoint();
+
+            var metadataAttributeStrategy = new WebApiEndpointMetadataAttributeStrategy();
+
+            var metadatas = metadataAttributeStrategy.Get(configuration, webApiEndpoint);
+
+            metadatas.Count().Should().Be(1);
+
+            var metadata = metadatas.Single();
+
+            metadata.PrefixRoute.Should().Be($"v{{version:apiVersion}}/{ROUTE}");
+            metadata.Tag.Should().Be(TAG);
+            metadata.WebApiEndpointVersion.Should().Be(V_DEFAULT);
+        }
+
+        [Fact]
+        public void tag_missing()
+        {
+            var configuration = new WebApiEndpointConfiguration(V_DEFAULT);
+
+            var webApiEndpoint = new TagMissingWebApiEndpoint();
+
+            var metadataAttributeStrategy = new WebApiEndpointMetadataAttributeStrategy();
+
+            var metadatas = metadataAttributeStrategy.Get(configuration, webApiEndpoint);
+
+            metadatas.Count().Should().Be(1);
+
+            var metadata = metadatas.Single();
+
+            metadata.PrefixRoute.Should().Be($"v{{version:apiVersion}}/{ROUTE}");
+            metadata.Tag.Should().Be(ROUTE);
+            metadata.WebApiEndpointVersion.Should().Be(V0_1);
+        }
+
+        [Fact]
+        public void tag_and_route_missing()
+        {
+            var configuration = new WebApiEndpointConfiguration(V_DEFAULT);
+
+            var webApiEndpoint = new TagAndRouteMissingWebApiEndpoint();
+
+            var metadataAttributeStrategy = new WebApiEndpointMetadataAttributeStrategy();
+
+            var metadatas = metadataAttributeStrategy.Get(configuration, webApiEndpoint);
+
+            metadatas.Count().Should().Be(1);
+
+            var metadata = metadatas.Single();
+
+            metadata.PrefixRoute.Should().Be($"v{{version:apiVersion}}/");
+            metadata.Tag.Should().Be(string.Empty);
+            metadata.WebApiEndpointVersion.Should().Be(V0_1);
+        }
+
+        [Fact]
+        public void version_prefix_override()
+        {
+            const string versionPrefix = "v2";
+
+            var configuration = new WebApiEndpointConfiguration(V_DEFAULT)
+            {
+                VersionPrefix = versionPrefix
+            };
+
+            var webApiEndpoint = new TagAndRouteMissingWebApiEndpoint();
+
+            var metadataAttributeStrategy = new WebApiEndpointMetadataAttributeStrategy();
+
+            var metadatas = metadataAttributeStrategy.Get(configuration, webApiEndpoint);
+
+            metadatas.Count().Should().Be(1);
+
+            var metadata = metadatas.Single();
+
+            metadata.PrefixRoute.Should().Be($"{versionPrefix}{{version:apiVersion}}/");
+            metadata.Tag.Should().Be(string.Empty);
+            metadata.WebApiEndpointVersion.Should().Be(V0_1);
+        }
+
+        [WebApiEndpoint(ROUTE, TAG)]
+        [V0_1]
+        public class AllPopulatedWebApiEndpoint : IWebApiEndpoint
+        {
+            public void Register(IEndpointRouteBuilder builder)
+            {
+            }
+        }
+
+        [WebApiEndpoint(ROUTE, TAG)]
+        public class VersionMissingWebApiEndpoint : IWebApiEndpoint
+        {
+            public void Register(IEndpointRouteBuilder builder)
+            {
+            }
+        }
+
+        [WebApiEndpoint(ROUTE)]
+        [V0_1]
+        public class TagMissingWebApiEndpoint : IWebApiEndpoint
+        {
+            public void Register(IEndpointRouteBuilder builder)
+            {
+            }
+        }
+
+        [WebApiEndpoint]
+        [V0_1]
+        public class TagAndRouteMissingWebApiEndpoint : IWebApiEndpoint
+        {
+            public void Register(IEndpointRouteBuilder builder)
+            {
+            }
+        }
+
+        /// <inheritdoc />
+        public class V0_1Attribute : WebApiEndpointVersionAttribute
+        {
+            public V0_1Attribute()
+                : base(V0_1.MajorVersion, V0_1.MinorVersion)
+            {
+            }
+        }
+    }
+
+    public class multiple_versions
+    {
+        private const string ROUTE = "route";
+        private const string TAG = "tag";
+
+        public static readonly WebApiEndpointVersion V_DEFAULT = new(1, 0);
+        public static readonly WebApiEndpointVersion V0_1 = new(0, 1);
+        public static readonly WebApiEndpointVersion V2_0 = new(2, 0);
+
+        [Fact]
+        public void all_populated()
+        {
+            var configuration = new WebApiEndpointConfiguration(V_DEFAULT);
+
+            var webApiEndpoint = new AllPopulatedWebApiEndpoint();
+
+            var metadataAttributeStrategy = new WebApiEndpointMetadataAttributeStrategy();
+
+            var metadatas = metadataAttributeStrategy.Get(configuration, webApiEndpoint);
+
+            metadatas.Count().Should().Be(2);
+
+            var metadata1 = metadatas.First();
+
+            metadata1.PrefixRoute.Should().Be($"v{{version:apiVersion}}/{ROUTE}");
+            metadata1.Tag.Should().Be(TAG);
+            metadata1.WebApiEndpointVersion.Should().Be(V0_1);
+
+            var metadata2 = metadatas.Skip(1).First();
+
+            metadata2.PrefixRoute.Should().Be($"v{{version:apiVersion}}/{ROUTE}");
+            metadata2.Tag.Should().Be(TAG);
+            metadata2.WebApiEndpointVersion.Should().Be(V2_0);
+        }
+
+        [Fact]
+        public void tag_missing()
+        {
+            var configuration = new WebApiEndpointConfiguration(V_DEFAULT);
+
+            var webApiEndpoint = new TagMissingWebApiEndpoint();
+
+            var metadataAttributeStrategy = new WebApiEndpointMetadataAttributeStrategy();
+
+            var metadatas = metadataAttributeStrategy.Get(configuration, webApiEndpoint);
+
+            metadatas.Count().Should().Be(2);
+
+            var metadata1 = metadatas.First();
+
+            metadata1.PrefixRoute.Should().Be($"v{{version:apiVersion}}/{ROUTE}");
+            metadata1.Tag.Should().Be(ROUTE);
+            metadata1.WebApiEndpointVersion.Should().Be(V0_1);
+
+            var metadata2 = metadatas.Skip(1).First();
+
+            metadata2.PrefixRoute.Should().Be($"v{{version:apiVersion}}/{ROUTE}");
+            metadata2.Tag.Should().Be(ROUTE);
+            metadata2.WebApiEndpointVersion.Should().Be(V2_0);
+        }
+
+        [Fact]
+        public void tag_and_route_missing()
+        {
+            var configuration = new WebApiEndpointConfiguration(V_DEFAULT);
+
+            var webApiEndpoint = new TagAndRouteMissingWebApiEndpoint();
+
+            var metadataAttributeStrategy = new WebApiEndpointMetadataAttributeStrategy();
+
+            var metadatas = metadataAttributeStrategy.Get(configuration, webApiEndpoint);
+
+            metadatas.Count().Should().Be(2);
+
+            var metadata1 = metadatas.First();
+
+            metadata1.PrefixRoute.Should().Be($"v{{version:apiVersion}}/");
+            metadata1.Tag.Should().Be(string.Empty);
+            metadata1.WebApiEndpointVersion.Should().Be(V0_1);
+
+            var metadata2 = metadatas.Skip(1).First();
+
+            metadata2.PrefixRoute.Should().Be($"v{{version:apiVersion}}/");
+            metadata2.Tag.Should().Be(string.Empty);
+            metadata2.WebApiEndpointVersion.Should().Be(V2_0);
+        }
+
+        [Fact]
+        public void version_prefix_override()
+        {
+            const string versionPrefix = "v2";
+
+            var configuration = new WebApiEndpointConfiguration(V_DEFAULT)
+            {
+                VersionPrefix = versionPrefix
+            };
+
+            var webApiEndpoint = new TagAndRouteMissingWebApiEndpoint();
+
+            var metadataAttributeStrategy = new WebApiEndpointMetadataAttributeStrategy();
+
+            var metadatas = metadataAttributeStrategy.Get(configuration, webApiEndpoint);
+
+            metadatas.Count().Should().Be(2);
+
+            var metadata1 = metadatas.First();
+
+            metadata1.PrefixRoute.Should().Be($"{versionPrefix}{{version:apiVersion}}/");
+            metadata1.Tag.Should().Be(string.Empty);
+            metadata1.WebApiEndpointVersion.Should().Be(V0_1);
+
+            var metadata2 = metadatas.Skip(1).First();
+
+            metadata2.PrefixRoute.Should().Be($"{versionPrefix}{{version:apiVersion}}/");
+            metadata2.Tag.Should().Be(string.Empty);
+            metadata2.WebApiEndpointVersion.Should().Be(V2_0);
+        }
+
+        [WebApiEndpoint(ROUTE, TAG)]
+        [V0_1]
+        [V2_0]
+        public class AllPopulatedWebApiEndpoint : IWebApiEndpoint
+        {
+            public void Register(IEndpointRouteBuilder builder)
+            {
+            }
+        }
+
+        [WebApiEndpoint(ROUTE)]
+        [V0_1]
+        [V2_0]
+        public class TagMissingWebApiEndpoint : IWebApiEndpoint
+        {
+            public void Register(IEndpointRouteBuilder builder)
+            {
+            }
+        }
+
+        [WebApiEndpoint]
+        [V0_1]
+        [V2_0]
+        public class TagAndRouteMissingWebApiEndpoint : IWebApiEndpoint
+        {
+            public void Register(IEndpointRouteBuilder builder)
+            {
+            }
+        }
+
+        /// <inheritdoc />
+        public class V0_1Attribute : WebApiEndpointVersionAttribute
+        {
+            public V0_1Attribute()
+                : base(V0_1.MajorVersion, V0_1.MinorVersion)
+            {
+            }
+        }
+
+        /// <inheritdoc />
+        public class V2_0Attribute : WebApiEndpointVersionAttribute
+        {
+            public V2_0Attribute()
+                : base(V2_0.MajorVersion, V2_0.MinorVersion)
+            {
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Improve README.md.
- Extract MetadataStrategy out and allow it to be overriden with custom implementation.
- Make IWebApiEndpoint.Configure have a default implementation of nothing, so you only need to implement it if you want to use it.
- Add explicit extension methods to add convention customisations