### PR TITLE
Improve OpenAPI information

### DIFF
--- a/sample/Futurum.WebApiEndpoint.Micro.Sample/Program.cs
+++ b/sample/Futurum.WebApiEndpoint.Micro.Sample/Program.cs
@@ -2,8 +2,6 @@ using Futurum.Microsoft.Extensions.DependencyInjection;
 using Futurum.WebApiEndpoint.Micro;
 using Futurum.WebApiEndpoint.Micro.Sample;
 
-using Microsoft.OpenApi.Models;
-
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddExceptionHandler<GlobalExceptionHandler>();
@@ -20,21 +18,35 @@ builder.Services.AddOutputCaches();
 builder.Services
        .AddWebApiEndpoints(new WebApiEndpointConfiguration(WebApiEndpointVersions.V1_0.Version)
        {
-           OpenApi =
+           OpenApi = new()
            {
-               DefaultInfo =
+               DefaultInfo = new()
                {
                    Title = "Futurum.WebApiEndpoint.Micro.Sample",
+                   Description = "OpenAPI description default",
+                   Contact = new()
+                   {
+                       Email = "a@b.com",
+                       Name = "A B",
+                       Url = new Uri("https://www.google.com")
+                   },
+                   License = new()
+                   {
+                       Name = "MIT"
+                   },
+                   TermsOfService = new Uri("https://www.google.com")
                },
-               VersionedInfo =
+               VersionedOverrideInfo =
                {
                    {
                        WebApiEndpointVersions.V3_0.Version,
-                       new OpenApiInfo
+                       new WebApiEndpointOpenApiInfo
                        {
-                           Title = "Futurum.WebApiEndpoint.Micro.Sample v3"
+                           Title = "Futurum.WebApiEndpoint.Micro.Sample v3",
+                           Description = "OpenAPI description v3",
+                           TermsOfService = new Uri("https://www.bing.com")
                        }
-                   }
+                   },
                }
            }
        })

--- a/sample/Futurum.WebApiEndpoint.Micro.Sample/WebApiEndpointVersions.cs
+++ b/sample/Futurum.WebApiEndpoint.Micro.Sample/WebApiEndpointVersions.cs
@@ -1,5 +1,3 @@
-using Futurum.WebApiEndpoint.Micro.Generator;
-
 namespace Futurum.WebApiEndpoint.Micro.Sample;
 
 public static class WebApiEndpointVersions

--- a/src/Futurum.WebApiEndpoint.Micro/WebApiEndpointConfiguration.cs
+++ b/src/Futurum.WebApiEndpoint.Micro/WebApiEndpointConfiguration.cs
@@ -1,7 +1,5 @@
 using Asp.Versioning;
 
-using Microsoft.OpenApi.Models;
-
 namespace Futurum.WebApiEndpoint.Micro;
 
 /// <summary>
@@ -10,7 +8,7 @@ namespace Futurum.WebApiEndpoint.Micro;
 /// <param name="DefaultWebApiEndpointVersion"></param>
 public record WebApiEndpointConfiguration(WebApiEndpointVersion DefaultWebApiEndpointVersion)
 {
-    public WebApiEndpointOpenApiConfiguration OpenApi { get; } = new();
+    public required WebApiEndpointOpenApiConfiguration OpenApi { get; set; }
 
     public WebApiEndpointVersionConfiguration Version { get; } = new();
 
@@ -18,15 +16,16 @@ public record WebApiEndpointConfiguration(WebApiEndpointVersion DefaultWebApiEnd
     {
         /// <summary>
         /// Default OpenApiInfo for all versions.
-        /// <remarks>Unless overridden by <see cref="VersionedInfo"/>.</remarks>
+        /// <remarks>Unless overridden by <see cref="VersionedOverrideInfo"/>.</remarks>
         /// </summary>
-        public OpenApiInfo DefaultInfo { get; } = new();
+        public required WebApiEndpointOpenApiInfo DefaultInfo { get; set; }
 
         /// <summary>
-        /// OpenApiInfo for a specific version.
-        /// <remarks>If version is not specified, <see cref="DefaultInfo"/> is used.</remarks>
+        /// OpenApiInfo overrides for a specific version.
+        /// <remarks>If a version is not specified, <see cref="DefaultInfo"/> is used.</remarks>
+        /// <remarks>If a property on a version is not specified, that property from <see cref="DefaultInfo"/> is used.</remarks>
         /// </summary>
-        public IDictionary<ApiVersion, OpenApiInfo> VersionedInfo { get; } = new Dictionary<ApiVersion, OpenApiInfo>();
+        public IDictionary<ApiVersion, WebApiEndpointOpenApiInfo> VersionedOverrideInfo { get; } = new Dictionary<ApiVersion, WebApiEndpointOpenApiInfo>();
     }
 
     public class WebApiEndpointVersionConfiguration

--- a/src/Futurum.WebApiEndpoint.Micro/WebApiEndpointOpenApiInfo.cs
+++ b/src/Futurum.WebApiEndpoint.Micro/WebApiEndpointOpenApiInfo.cs
@@ -1,0 +1,37 @@
+using Microsoft.OpenApi.Interfaces;
+using Microsoft.OpenApi.Models;
+
+namespace Futurum.WebApiEndpoint.Micro;
+
+public class WebApiEndpointOpenApiInfo
+{
+    /// <summary>
+    /// REQUIRED. The title of the application.
+    /// </summary>
+    public required string Title { get; set; }
+
+    /// <summary>
+    /// A short description of the application.
+    /// </summary>
+    public string? Description { get; set; }
+
+    /// <summary>
+    /// A URL to the Terms of Service for the API. MUST be in the format of a URL.
+    /// </summary>
+    public Uri? TermsOfService { get; set; }
+
+    /// <summary>
+    /// The contact information for the exposed API.
+    /// </summary>
+    public OpenApiContact? Contact { get; set; }
+
+    /// <summary>
+    /// The license information for the exposed API.
+    /// </summary>
+    public OpenApiLicense? License { get; set; }
+
+    /// <summary>
+    /// This object MAY be extended with Specification Extensions.
+    /// </summary>
+    public IDictionary<string, IOpenApiExtension> Extensions { get; } = new Dictionary<string, IOpenApiExtension>();
+}

--- a/test/Futurum.WebApiEndpoint.Micro.Tests/WebApiOpenApiVersionConfigurationServiceTests.cs
+++ b/test/Futurum.WebApiEndpoint.Micro.Tests/WebApiOpenApiVersionConfigurationServiceTests.cs
@@ -1,7 +1,9 @@
 using Asp.Versioning;
 using Asp.Versioning.ApiExplorer;
 
-using Futurum.WebApiEndpoint.Micro.Generator;
+using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Interfaces;
+using Microsoft.OpenApi.Models;
 
 namespace Futurum.WebApiEndpoint.Micro.Tests;
 
@@ -10,7 +12,17 @@ public class WebApiOpenApiVersionConfigurationServiceTests
     [Fact]
     public void when_IsDeprecated()
     {
-        var webApiOpenApiVersionConfigurationService = new WebApiOpenApiVersionConfigurationService(new WebApiEndpointConfiguration(WebApiEndpointVersion.Create(1.0d)));
+        var webApiEndpointConfiguration = new WebApiEndpointConfiguration(WebApiEndpointVersion.Create(1.0d))
+        {
+            OpenApi = new()
+            {
+                DefaultInfo = new()
+                {
+                    Title = "",
+                }
+            }
+        };
+        var webApiOpenApiVersionConfigurationService = new WebApiOpenApiVersionConfigurationService(webApiEndpointConfiguration);
 
         var apiVersionDescription = new ApiVersionDescription(new ApiVersion(1, 0), string.Empty, true, null);
 
@@ -22,7 +34,17 @@ public class WebApiOpenApiVersionConfigurationServiceTests
     [Fact]
     public void when_SunsetPolicy()
     {
-        var webApiOpenApiVersionConfigurationService = new WebApiOpenApiVersionConfigurationService(new WebApiEndpointConfiguration(WebApiEndpointVersion.Create(1.0d)));
+        var webApiEndpointConfiguration = new WebApiEndpointConfiguration(WebApiEndpointVersion.Create(1.0d))
+        {
+            OpenApi = new()
+            {
+                DefaultInfo = new()
+                {
+                    Title = "",
+                }
+            }
+        };
+        var webApiOpenApiVersionConfigurationService = new WebApiOpenApiVersionConfigurationService(webApiEndpointConfiguration);
 
         var linkHeaderValue = new LinkHeaderValue(new Uri("https://www.google.com"), "sunset")
         {
@@ -36,5 +58,571 @@ public class WebApiOpenApiVersionConfigurationServiceTests
         var openApiInfo = webApiOpenApiVersionConfigurationService.CreateOpenApiInfo(apiVersionDescription);
 
         openApiInfo.Description.Should().Be($" The API will be sunset on 01/01/2021.{Environment.NewLine}{Environment.NewLine}Test: https://www.google.com");
+    }
+
+    public class VersionOverrides
+    {
+        public class Title
+        {
+            [Fact]
+            public void Default()
+            {
+                var titleDefault = Guid.NewGuid().ToString();
+                var titleV3 = Guid.NewGuid().ToString();
+
+                var webApiEndpointConfiguration = new WebApiEndpointConfiguration(WebApiEndpointVersion.Create(1.0d))
+                {
+                    OpenApi = new()
+                    {
+                        DefaultInfo = new()
+                        {
+                            Title = titleDefault,
+                        },
+                        VersionedOverrideInfo =
+                        {
+                            {
+                                new ApiVersion(3, 0),
+                                new WebApiEndpointOpenApiInfo
+                                {
+                                    Title = titleV3
+                                }
+                            }
+                        }
+                    }
+                };
+                var webApiOpenApiVersionConfigurationService = new WebApiOpenApiVersionConfigurationService(webApiEndpointConfiguration);
+
+                var apiVersionDescription = new ApiVersionDescription(new ApiVersion(2, 0), string.Empty, false, null);
+
+                var openApiInfo = webApiOpenApiVersionConfigurationService.CreateOpenApiInfo(apiVersionDescription);
+
+                openApiInfo.Title.Should().Be(titleDefault);
+            }
+
+            [Fact]
+            public void Override()
+            {
+                var apiVersion = new ApiVersion(2, 0);
+
+                var titleVersionOverride = Guid.NewGuid().ToString();
+
+                var webApiEndpointConfiguration = new WebApiEndpointConfiguration(WebApiEndpointVersion.Create(1.0d))
+                {
+                    OpenApi = new()
+                    {
+                        DefaultInfo = new()
+                        {
+                            Title = "",
+                        },
+                        VersionedOverrideInfo =
+                        {
+                            {
+                                apiVersion,
+                                new WebApiEndpointOpenApiInfo
+                                {
+                                    Title = titleVersionOverride
+                                }
+                            }
+                        }
+                    }
+                };
+                var webApiOpenApiVersionConfigurationService = new WebApiOpenApiVersionConfigurationService(webApiEndpointConfiguration);
+
+                var apiVersionDescription = new ApiVersionDescription(apiVersion, string.Empty, false, null);
+
+                var openApiInfo = webApiOpenApiVersionConfigurationService.CreateOpenApiInfo(apiVersionDescription);
+
+                openApiInfo.Title.Should().Be(titleVersionOverride);
+            }
+        }
+
+        public class Description
+        {
+            [Fact]
+            public void Default()
+            {
+                var descriptionDefault = Guid.NewGuid().ToString();
+                var descriptionV3 = Guid.NewGuid().ToString();
+
+                var webApiEndpointConfiguration = new WebApiEndpointConfiguration(WebApiEndpointVersion.Create(1.0d))
+                {
+                    OpenApi = new()
+                    {
+                        DefaultInfo = new()
+                        {
+                            Title = Guid.NewGuid().ToString(),
+                            Description = descriptionDefault,
+                        },
+                        VersionedOverrideInfo =
+                        {
+                            {
+                                new ApiVersion(3, 0),
+                                new WebApiEndpointOpenApiInfo
+                                {
+                                    Title = Guid.NewGuid().ToString(),
+                                    Description = descriptionV3
+                                }
+                            }
+                        }
+                    }
+                };
+                var webApiOpenApiVersionConfigurationService = new WebApiOpenApiVersionConfigurationService(webApiEndpointConfiguration);
+
+                var apiVersionDescription = new ApiVersionDescription(new ApiVersion(2, 0), string.Empty, false, null);
+
+                var openApiInfo = webApiOpenApiVersionConfigurationService.CreateOpenApiInfo(apiVersionDescription);
+
+                openApiInfo.Description.Should().Be(descriptionDefault);
+            }
+
+            [Fact]
+            public void Override()
+            {
+                var apiVersion = new ApiVersion(2, 0);
+
+                var descriptionVersionOverride = Guid.NewGuid().ToString();
+
+                var webApiEndpointConfiguration = new WebApiEndpointConfiguration(WebApiEndpointVersion.Create(1.0d))
+                {
+                    OpenApi = new()
+                    {
+                        DefaultInfo = new()
+                        {
+                            Title = Guid.NewGuid().ToString(),
+                        },
+                        VersionedOverrideInfo =
+                        {
+                            {
+                                apiVersion,
+                                new WebApiEndpointOpenApiInfo
+                                {
+                                    Title = Guid.NewGuid().ToString(),
+                                    Description = descriptionVersionOverride
+                                }
+                            }
+                        }
+                    }
+                };
+                var webApiOpenApiVersionConfigurationService = new WebApiOpenApiVersionConfigurationService(webApiEndpointConfiguration);
+
+                var apiVersionDescription = new ApiVersionDescription(apiVersion, string.Empty, false, null);
+
+                var openApiInfo = webApiOpenApiVersionConfigurationService.CreateOpenApiInfo(apiVersionDescription);
+
+                openApiInfo.Description.Should().Be(descriptionVersionOverride);
+            }
+        }
+
+        public class TermsOfService
+        {
+            [Fact]
+            public void Default()
+            {
+                var termsOfServiceDefault = new Uri("https://www.google.com");
+                var termsOfServiceV3 = new Uri("https://www.bing.com");
+
+                var webApiEndpointConfiguration = new WebApiEndpointConfiguration(WebApiEndpointVersion.Create(1.0d))
+                {
+                    OpenApi = new()
+                    {
+                        DefaultInfo = new()
+                        {
+                            Title = Guid.NewGuid().ToString(),
+                            TermsOfService = termsOfServiceDefault,
+                        },
+                        VersionedOverrideInfo =
+                        {
+                            {
+                                new ApiVersion(3, 0),
+                                new WebApiEndpointOpenApiInfo
+                                {
+                                    Title = Guid.NewGuid().ToString(),
+                                    TermsOfService = termsOfServiceV3
+                                }
+                            }
+                        }
+                    }
+                };
+                var webApiOpenApiVersionConfigurationService = new WebApiOpenApiVersionConfigurationService(webApiEndpointConfiguration);
+
+                var apiVersionDescription = new ApiVersionDescription(new ApiVersion(2, 0), string.Empty, false, null);
+
+                var openApiInfo = webApiOpenApiVersionConfigurationService.CreateOpenApiInfo(apiVersionDescription);
+
+                openApiInfo.TermsOfService.Should().Be(termsOfServiceDefault);
+            }
+
+            [Fact]
+            public void Override()
+            {
+                var apiVersion = new ApiVersion(2, 0);
+
+                var termsOfServiceVersionOverride = new Uri("https://www.bing.com");
+
+                var webApiEndpointConfiguration = new WebApiEndpointConfiguration(WebApiEndpointVersion.Create(1.0d))
+                {
+                    OpenApi = new()
+                    {
+                        DefaultInfo = new()
+                        {
+                            Title = Guid.NewGuid().ToString(),
+                        },
+                        VersionedOverrideInfo =
+                        {
+                            {
+                                apiVersion,
+                                new WebApiEndpointOpenApiInfo
+                                {
+                                    Title = Guid.NewGuid().ToString(),
+                                    TermsOfService = termsOfServiceVersionOverride
+                                }
+                            }
+                        }
+                    }
+                };
+                var webApiOpenApiVersionConfigurationService = new WebApiOpenApiVersionConfigurationService(webApiEndpointConfiguration);
+
+                var apiVersionDescription = new ApiVersionDescription(apiVersion, string.Empty, false, null);
+
+                var openApiInfo = webApiOpenApiVersionConfigurationService.CreateOpenApiInfo(apiVersionDescription);
+
+                openApiInfo.TermsOfService.Should().Be(termsOfServiceVersionOverride);
+            }
+        }
+
+        public class Contact
+        {
+            [Fact]
+            public void Default()
+            {
+                var contactDefault = new OpenApiContact
+                {
+                    Name = Guid.NewGuid().ToString(),
+                    Email = Guid.NewGuid().ToString(),
+                    Url = new Uri("https://www.google.com")
+                };
+                var contactV3 = new OpenApiContact
+                {
+                    Name = Guid.NewGuid().ToString(),
+                    Email = Guid.NewGuid().ToString(),
+                    Url = new Uri("https://www.bing.com")
+                };
+
+                var webApiEndpointConfiguration = new WebApiEndpointConfiguration(WebApiEndpointVersion.Create(1.0d))
+                {
+                    OpenApi = new()
+                    {
+                        DefaultInfo = new()
+                        {
+                            Title = Guid.NewGuid().ToString(),
+                            Contact = contactDefault,
+                        },
+                        VersionedOverrideInfo =
+                        {
+                            {
+                                new ApiVersion(3, 0),
+                                new WebApiEndpointOpenApiInfo
+                                {
+                                    Title = Guid.NewGuid().ToString(),
+                                    Contact = contactV3
+                                }
+                            }
+                        }
+                    }
+                };
+                var webApiOpenApiVersionConfigurationService = new WebApiOpenApiVersionConfigurationService(webApiEndpointConfiguration);
+
+                var apiVersionDescription = new ApiVersionDescription(new ApiVersion(2, 0), string.Empty, false, null);
+
+                var openApiInfo = webApiOpenApiVersionConfigurationService.CreateOpenApiInfo(apiVersionDescription);
+
+                openApiInfo.Contact.Should().BeEquivalentTo(contactDefault);
+            }
+
+            [Fact]
+            public void Override()
+            {
+                var apiVersion = new ApiVersion(2, 0);
+
+                var contactVersionOverride = new OpenApiContact
+                {
+                    Name = Guid.NewGuid().ToString(),
+                    Email = Guid.NewGuid().ToString(),
+                    Url = new Uri("https://www.bing.com")
+                };
+
+                var webApiEndpointConfiguration = new WebApiEndpointConfiguration(WebApiEndpointVersion.Create(1.0d))
+                {
+                    OpenApi = new()
+                    {
+                        DefaultInfo = new()
+                        {
+                            Title = Guid.NewGuid().ToString(),
+                        },
+                        VersionedOverrideInfo =
+                        {
+                            {
+                                apiVersion,
+                                new WebApiEndpointOpenApiInfo
+                                {
+                                    Title = Guid.NewGuid().ToString(),
+                                    Contact = contactVersionOverride
+                                }
+                            }
+                        }
+                    }
+                };
+                var webApiOpenApiVersionConfigurationService = new WebApiOpenApiVersionConfigurationService(webApiEndpointConfiguration);
+
+                var apiVersionDescription = new ApiVersionDescription(apiVersion, string.Empty, false, null);
+
+                var openApiInfo = webApiOpenApiVersionConfigurationService.CreateOpenApiInfo(apiVersionDescription);
+
+                openApiInfo.Contact.Should().BeEquivalentTo(contactVersionOverride);
+            }
+        }
+
+        public class License
+        {
+            [Fact]
+            public void Default()
+            {
+                var licenseDefault = new OpenApiLicense
+                {
+                    Name = Guid.NewGuid().ToString(),
+                    Url = new Uri("https://www.google.com")
+                };
+                var licenseV3 = new OpenApiLicense
+                {
+                    Name = Guid.NewGuid().ToString(),
+                    Url = new Uri("https://www.bing.com")
+                };
+
+                var webApiEndpointConfiguration = new WebApiEndpointConfiguration(WebApiEndpointVersion.Create(1.0d))
+                {
+                    OpenApi = new()
+                    {
+                        DefaultInfo = new()
+                        {
+                            Title = Guid.NewGuid().ToString(),
+                            License = licenseDefault,
+                        },
+                        VersionedOverrideInfo =
+                        {
+                            {
+                                new ApiVersion(3, 0),
+                                new WebApiEndpointOpenApiInfo
+                                {
+                                    Title = Guid.NewGuid().ToString(),
+                                    License = licenseV3
+                                }
+                            }
+                        }
+                    }
+                };
+                var webApiOpenApiVersionConfigurationService = new WebApiOpenApiVersionConfigurationService(webApiEndpointConfiguration);
+
+                var apiVersionDescription = new ApiVersionDescription(new ApiVersion(2, 0), string.Empty, false, null);
+
+                var openApiInfo = webApiOpenApiVersionConfigurationService.CreateOpenApiInfo(apiVersionDescription);
+
+                openApiInfo.License.Should().BeEquivalentTo(licenseDefault);
+            }
+
+            [Fact]
+            public void Override()
+            {
+                var apiVersion = new ApiVersion(2, 0);
+
+                var licenseVersionOverride = new OpenApiLicense
+                {
+                    Name = Guid.NewGuid().ToString(),
+                    Url = new Uri("https://www.bing.com")
+                };
+
+                var webApiEndpointConfiguration = new WebApiEndpointConfiguration(WebApiEndpointVersion.Create(1.0d))
+                {
+                    OpenApi = new()
+                    {
+                        DefaultInfo = new()
+                        {
+                            Title = Guid.NewGuid().ToString(),
+                        },
+                        VersionedOverrideInfo =
+                        {
+                            {
+                                apiVersion,
+                                new WebApiEndpointOpenApiInfo
+                                {
+                                    Title = Guid.NewGuid().ToString(),
+                                    License = licenseVersionOverride
+                                }
+                            }
+                        }
+                    }
+                };
+                var webApiOpenApiVersionConfigurationService = new WebApiOpenApiVersionConfigurationService(webApiEndpointConfiguration);
+
+                var apiVersionDescription = new ApiVersionDescription(apiVersion, string.Empty, false, null);
+
+                var openApiInfo = webApiOpenApiVersionConfigurationService.CreateOpenApiInfo(apiVersionDescription);
+
+                openApiInfo.License.Should().BeEquivalentTo(licenseVersionOverride);
+            }
+        }
+
+        public class Extensions
+        {
+            [Fact]
+            public void Default()
+            {
+                var defaultKey = Guid.NewGuid().ToString();
+                var defaultValue = Guid.NewGuid().ToString();
+
+                var versionedKey = Guid.NewGuid().ToString();
+                var versionedValue = Guid.NewGuid().ToString();
+
+                var webApiEndpointConfiguration = new WebApiEndpointConfiguration(WebApiEndpointVersion.Create(1.0d))
+                {
+                    OpenApi = new()
+                    {
+                        DefaultInfo = new()
+                        {
+                            Title = Guid.NewGuid().ToString(),
+                            Extensions =
+                            {
+                                { defaultKey, new OpenApiString(defaultValue) }
+                            },
+                        },
+                        VersionedOverrideInfo =
+                        {
+                            {
+                                new ApiVersion(3, 0),
+                                new WebApiEndpointOpenApiInfo
+                                {
+                                    Title = Guid.NewGuid().ToString(),
+                                    Extensions =
+                                    {
+                                        { versionedKey, new OpenApiString(versionedValue) }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                };
+                var webApiOpenApiVersionConfigurationService = new WebApiOpenApiVersionConfigurationService(webApiEndpointConfiguration);
+
+                var apiVersionDescription = new ApiVersionDescription(new ApiVersion(2, 0), string.Empty, false, null);
+
+                var openApiInfo = webApiOpenApiVersionConfigurationService.CreateOpenApiInfo(apiVersionDescription);
+
+                openApiInfo.Extensions.Should().BeEquivalentTo(new Dictionary<string, IOpenApiExtension>
+                {
+                    { defaultKey, new OpenApiString(defaultValue) }
+                });
+            }
+
+            [Fact]
+            public void Override_Merge()
+            {
+                var apiVersion = new ApiVersion(2, 0);
+
+                var defaultKey = Guid.NewGuid().ToString();
+                var defaultValue = Guid.NewGuid().ToString();
+
+                var versionedKey = Guid.NewGuid().ToString();
+                var versionedValue = Guid.NewGuid().ToString();
+
+                var webApiEndpointConfiguration = new WebApiEndpointConfiguration(WebApiEndpointVersion.Create(1.0d))
+                {
+                    OpenApi = new()
+                    {
+                        DefaultInfo = new()
+                        {
+                            Title = Guid.NewGuid().ToString(),
+                            Extensions =
+                            {
+                                { defaultKey, new OpenApiString(defaultValue) }
+                            },
+                        },
+                        VersionedOverrideInfo =
+                        {
+                            {
+                                apiVersion,
+                                new WebApiEndpointOpenApiInfo
+                                {
+                                    Title = Guid.NewGuid().ToString(),
+                                    Extensions =
+                                    {
+                                        { versionedKey, new OpenApiString(versionedValue) }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                };
+                var webApiOpenApiVersionConfigurationService = new WebApiOpenApiVersionConfigurationService(webApiEndpointConfiguration);
+
+                var apiVersionDescription = new ApiVersionDescription(apiVersion, string.Empty, false, null);
+
+                var openApiInfo = webApiOpenApiVersionConfigurationService.CreateOpenApiInfo(apiVersionDescription);
+
+                openApiInfo.Extensions.Should().BeEquivalentTo(new Dictionary<string, IOpenApiExtension>
+                {
+                    { defaultKey, new OpenApiString(defaultValue) },
+                    { versionedKey, new OpenApiString(versionedValue) }
+                });
+            }
+
+            [Fact]
+            public void Override_Replace()
+            {
+                var apiVersion = new ApiVersion(2, 0);
+
+                var key = Guid.NewGuid().ToString();
+                var defaultValue = Guid.NewGuid().ToString();
+
+                var versionedValue = Guid.NewGuid().ToString();
+
+                var webApiEndpointConfiguration = new WebApiEndpointConfiguration(WebApiEndpointVersion.Create(1.0d))
+                {
+                    OpenApi = new()
+                    {
+                        DefaultInfo = new()
+                        {
+                            Title = Guid.NewGuid().ToString(),
+                            Extensions =
+                            {
+                                { key, new OpenApiString(defaultValue) }
+                            },
+                        },
+                        VersionedOverrideInfo =
+                        {
+                            {
+                                apiVersion,
+                                new WebApiEndpointOpenApiInfo
+                                {
+                                    Title = Guid.NewGuid().ToString(),
+                                    Extensions =
+                                    {
+                                        { key, new OpenApiString(versionedValue) }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                };
+                var webApiOpenApiVersionConfigurationService = new WebApiOpenApiVersionConfigurationService(webApiEndpointConfiguration);
+
+                var apiVersionDescription = new ApiVersionDescription(apiVersion, string.Empty, false, null);
+
+                var openApiInfo = webApiOpenApiVersionConfigurationService.CreateOpenApiInfo(apiVersionDescription);
+
+                openApiInfo.Extensions.Should().BeEquivalentTo(new Dictionary<string, IOpenApiExtension>
+                {
+                    { key, new OpenApiString(versionedValue) }
+                });
+            }
+        }
     }
 }


### PR DESCRIPTION
- Correctly set the ApiVersion on OpenApiInfo
- WebApiEndpointConfiguration
-- Make 'DefaultInfo' mandatory
-- Change 'VersionedInfo' -> 'VersionedOverrideInfo' and use it for individual property overrides. For 'OpenApiInfo.Extensions' merge, but override by key.